### PR TITLE
Add missing else condition for inline if-expression

### DIFF
--- a/tasks/wordpress-install.yml
+++ b/tasks/wordpress-install.yml
@@ -35,7 +35,7 @@
       --dbhost={{ wp_db_host | quote }}
       --dbprefix={{ wp_db_prefix | quote }}
       --dbcharset={{ wp_db_charset | quote }}
-      {{ "--skip-check" if wp_db_skip_check }}
+      {{ "--skip-check" if wp_db_skip_check else "" }}
     creates: "{{ wp_path }}/wp-config.php"
   when: not wp_skip_config
 


### PR DESCRIPTION
Corrects the following error:
```
FAILED! => {"msg": "The task includes an option with an undefined variable. The error was: the inline if-expression on line 1 evaluated to false and no else section was defined.\n\nThe error appears to be in "[redacted]/provisioning/roles/rchouinard.wordpress/tasks/wordpress-install.yml': line 23, column 3, but may\nbe elsewhere in the file depending on the exact syntax problem.\n\nThe offending line appears to be:\n\n\n- name: Create WordPress configuration file\n  ^ here\n"}
```
Interestingly this did not fail in my testing but did when I tried to run the play in prod. I'm _pretty sure_ it would have evaluated false in my test environment as well, so I think it may only fail on certain configurations or versions. (Prod in this case is CentOS 8 running Ansible 2.9.18)